### PR TITLE
Basic Ansible Galaxy proxy support (collections) - 0.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ then install the plugin with the options shown below:
 Thanks to some upstream work in Nexus Repository, it's become a LOT easier to install a plugin. To install the `ansiblegalaxy` plugin, follow these steps:
 
 * Build the plugin with `mvn clean package -PbuildKar`
-* Copy the `nexus-repository-ansiblegalaxy-0.0.1-bundle.kar` file from your `target` folder to the `deploy` folder for your Nexus Repository installation.
+* Copy the `nexus-repository-ansiblegalaxy-*-bundle.kar` file from your `target` folder to the `deploy` folder for your Nexus Repository installation.
 
 Once you've done this, go ahead and either restart Nexus Repo, or go ahead and start it if it wasn't running to begin with.
 

--- a/README.md
+++ b/README.md
@@ -13,9 +13,8 @@
 
 -->
 <!-- generated with nexus-format-archetype version 1.0.48 on Dec 27, 2020 -->
-# Nexus Repository AnsibleGalaxy Format
+# Nexus Repository Ansible Galaxy Format
 
-[![Maven Central](https://img.shields.io/maven-central/v/org.sonatype.nexus.plugins/nexus-repository-ansiblegalaxy.svg?label=Maven%20Central)](https://search.maven.org/search?q=g:%22org.sonatype.nexus.plugins%22%20AND%20a:%22nexus-repository-ansiblegalaxy%22) [![CircleCI](https://circleci.com/gh/sonatype-nexus-community/nexus-repository-ansiblegalaxy.svg?style=shield)](https://circleci.com/gh/sonatype-nexus-community/nexus-repository-ansiblegalaxy) [![Join the chat at https://gitter.im/sonatype/nexus-developers](https://badges.gitter.im/sonatype/nexus-developers.svg)](https://gitter.im/sonatype/nexus-developers?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge) [![DepShield Badge](https://depshield.sonatype.org/badges/sonatype-nexus-community/nexus-repository-ansiblegalaxy/depshield.svg)](https://depshield.github.io)
 
 # Table Of Contents
 
@@ -23,10 +22,10 @@
    * [Requirements](#requirements)
    * [Download](#download)
    * [Building](#building)
-* [Using AnsibleGalaxy with Nexus Repository Manager 3](#using-ansiblegalaxy-with-nexus-repository-manager-3)
+* [Using Ansible Galaxy with Nexus Repository Manager 3](#using-ansiblegalaxy-with-nexus-repository-manager-3)
 * [Compatibility with Nexus Repository Manager 3 Versions](#compatibility-with-nexus-repository-manager-3-versions)
 * [Features Implemented In This Plugin](#features-implemented-in-this-plugin)
-   * [Supported AnsibleGalaxy Commands](#supported-ansiblegalaxy-commands)
+   * [Supported Ansible Galaxy Commands](#supported-ansible-galaxy-commands)
 * [Installing the plugin](#installing-the-plugin)
    * [Easiest Install](#easiest-install)
    * [Temporary Install](#temporary-install)
@@ -50,7 +49,7 @@ You may also find it helpful to configure your IDE to use the [Sonatype Code sty
 
 ### Download
 
- Find pre-compiled files [here](https://search.maven.org/search?q=g:%22org.sonatype.nexus.plugins%22%20AND%20a:%22nexus-repository-ansiblegalaxy%22).
+ Find pre-compiled files [here](https://github.com/l3ender/nexus-repository-ansiblegalaxy/releases).
 
 ### Building
 
@@ -95,7 +94,7 @@ table will be updated to indicate which version of Nexus Repository it will func
 available basis, as this is community supported. If you see a new version of Nexus Repository, go ahead and update the
 plugin and send us a PR after testing it out!
 
-All released versions can be found [here](https://github.com/sonatype-nexus-community/nexus-repository-ansiblegalaxy/releases).
+All released versions can be found [here](https://github.com/l3ender/nexus-repository-ansiblegalaxy/releases).
 
 ## Features Implemented In This Plugin 
 
@@ -105,13 +104,17 @@ All released versions can be found [here](https://github.com/sonatype-nexus-comm
 | Hosted  |                      |
 | Group   |                      |
 
-### Supported AnsibleGalaxy Commands
+### Supported `ansible-galaxy` Commands
 
 #### Proxy
 
 | Plugin Version               | Nexus Repository Version |
 |------------------------------|--------------------------|
-| `ansiblegalaxy client command`         | :heavy_check_mark:       |
+| `ansible-galaxy collection install`         | :heavy_check_mark:       |
+
+You must set the Galaxy API endpoint/server when using the client, either by:
+* provide the `-s API_SERVER` or `--server API_SERVER` argument for each installation command.
+* configure `GALAXY_SERVER` configuration value or `ANSIBLE_GALAXY_SERVER` environment varaible (see [doc](https://docs.ansible.com/ansible/latest/reference_appendices/config.html#galaxy-server)).
 
 ## Installing the plugin
 

--- a/README.md
+++ b/README.md
@@ -112,9 +112,8 @@ All released versions can be found [here](https://github.com/l3ender/nexus-repos
 |------------------------------|--------------------------|
 | `ansible-galaxy collection install`         | :heavy_check_mark:       |
 
-You must set the Galaxy API endpoint/server when using the client, either by:
-* provide the `-s API_SERVER` or `--server API_SERVER` argument for each installation command.
-* configure `GALAXY_SERVER` configuration value or `ANSIBLE_GALAXY_SERVER` environment varaible (see [doc](https://docs.ansible.com/ansible/latest/reference_appendices/config.html#galaxy-server)).
+Be sure to [configure the `ansible-galaxy` client](docs/ansiblegalaxy_user_documentation.md#configuring-the-ansible-galaxy-client).
+
 
 ## Installing the plugin
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ You may also find it helpful to configure your IDE to use the [Sonatype Code sty
 
 ### Download
 
- Find pre-compiled files [here](https://github.com/l3ender/nexus-repository-ansiblegalaxy/releases).
+ Pre-compiled plugin files can be found on the [releases page](https://github.com/l3ender/nexus-repository-ansiblegalaxy/releases).
 
 ### Building
 
@@ -94,7 +94,7 @@ table will be updated to indicate which version of Nexus Repository it will func
 available basis, as this is community supported. If you see a new version of Nexus Repository, go ahead and update the
 plugin and send us a PR after testing it out!
 
-All released versions can be found [here](https://github.com/l3ender/nexus-repository-ansiblegalaxy/releases).
+All released versions can be found on [the releases page](https://github.com/l3ender/nexus-repository-ansiblegalaxy/releases).
 
 ## Features Implemented In This Plugin 
 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ To read the generated admin password for your first login to the web UI, you can
 
 For simplicity, you should check `Enable anonymous access` in the prompts following your first login.   
 
-## Using AnsibleGalaxy With Nexus Repository Manager 3
+## Using Ansible Galaxy With Nexus Repository Manager 3
 
 [We have detailed instructions on how to get started here!](docs/ansiblegalaxy_user_documentation.md)
 
@@ -199,7 +199,7 @@ by the Sonatype Support team to remove the community item in order to determine 
 Remember:
 
 * Use this contribution at the risk tolerance that you have
-* Do NOT file Sonatype support tickets related to AnsibleGalaxy support in regard to this plugin
+* Do NOT file Sonatype support tickets related to Ansible Galaxy support in regard to this plugin
 * DO file issues here on GitHub, so that the community can pitch in
 
 Phew, that was easier than I thought. Last but not least of all:

--- a/docs/ansiblegalaxy_user_documentation.md
+++ b/docs/ansiblegalaxy_user_documentation.md
@@ -13,6 +13,7 @@
 
 -->
 
+### Overview
 
 [Ansible Galaxy](https://galaxy.ansible.com/) provides a way to install community collections and roles for Ansible.
 
@@ -22,6 +23,8 @@ Full documentation on installing `ansible-galaxy` can be found on [the Ansible G
 You can create a proxy repository in Nexus Repository Manager (NXRM) that will cache packages from a remote Ansible Galaxy repository, like
 [https://galaxy.ansible.com/](https://galaxy.ansible.com/). Then, you can make the `ansible-galaxy` client use your Nexus Repository Proxy 
 instead of the remote repository.
+
+### Repository configuration
  
 To proxy an Ansible Galaxy repository, you simply create a new 'ansiblegalaxy (proxy)' as documented in 
 [Repository Management](https://help.sonatype.com/repomanager3/configuration/repository-management) in
@@ -31,10 +34,22 @@ detail. Minimal configuration steps are:
 - Define URL for 'Remote storage' - e.g. [https://galaxy.ansible.com/](https://galaxy.ansible.com/)
 - Select a `Blob store` for `Storage`
 
-Using the `ansible-galaxy` client, you can now download packages from your NXRM AnsibleGalaxy proxy like so:
+### Configuring the `ansible-galaxy` client
+
+You must set the Galaxy API endpoint/server when using the client, either by:
+* provide the `-s API_SERVER` or `--server API_SERVER` argument for each installation command.
+* configure `GALAXY_SERVER` configuration value or `ANSIBLE_GALAXY_SERVER` environment variable.
+
+See the following resources for additional detail:
+* [Ansible documentation on configuring the `ansible-galaxy` client](https://docs.ansible.com/ansible/latest/galaxy/user_guide.html#configuring-the-ansible-galaxy-client).
+* [Ansible configuration documentation](https://docs.ansible.com/ansible/latest/reference_appendices/config.html#galaxy-server)).
+
+### Usage
+
+Using the `ansible-galaxy` client, you can now download packages from your NXRM Ansible Galaxy proxy:
 
 ```bash
 ansible-galaxy collection install azure.azcollection -s http://localhost:8081/repository/ansible/
 ```
-    
+
 The command above tells ansible-galaxy to fetch (and install) packages from your NXRM Ansible Galaxy proxy. The NXRM Ansible Galaxy proxy will download any missing packages from the remote Ansible Galaxy repository, and cache the packages on the NXRM Ansible Galaxy proxy. The next time any client requests the same package from your NXRM Ansible Galaxy proxy, the already cached package will be returned to the client.

--- a/docs/ansiblegalaxy_user_documentation.md
+++ b/docs/ansiblegalaxy_user_documentation.md
@@ -25,7 +25,7 @@ instead of the remote repository.
 
 ### Installation
 
-See [installing the plugin](../readme.md#installing-the-plugin).
+See [installing the plugin](../README.md#installing-the-plugin).
 
 ### Repository configuration
  

--- a/docs/ansiblegalaxy_user_documentation.md
+++ b/docs/ansiblegalaxy_user_documentation.md
@@ -14,29 +14,27 @@
 -->
 
 
-[AnsibleGalaxy](https://add_URL_To_Format_Info_Here/) provides Add_Format_Description_Here.
+[Ansible Galaxy](https://galaxy.ansible.com/) provides a way to install community collections and roles for Ansible.
+
+Full documentation on installing `ansible-galaxy` can be found on [the Ansible Galaxy project website](https://docs.ansible.com/ansible/latest/galaxy/user_guide.html).
 
 
-Full documentation on installing `ansiblegalaxy` can be found on [the AnsibleGalaxy project website](https://add_Format_Install_Info_URL/).
-
-
-You can create a proxy repository in Nexus Repository Manager (NXRM) that will cache packages from a remote AnsibleGalaxy repository, like
-[Add_Format_Repo_Name](https://add_format_repo_url/). Then, you can make the `ansiblegalaxy` client use your Nexus Repository Proxy 
+You can create a proxy repository in Nexus Repository Manager (NXRM) that will cache packages from a remote Ansible Galaxy repository, like
+[https://galaxy.ansible.com/](https://galaxy.ansible.com/). Then, you can make the `ansible-galaxy` client use your Nexus Repository Proxy 
 instead of the remote repository.
  
-To proxy a AnsibleGalaxy repository, you simply create a new 'ansiblegalaxy (proxy)' as documented in 
+To proxy an Ansible Galaxy repository, you simply create a new 'ansiblegalaxy (proxy)' as documented in 
 [Repository Management](https://help.sonatype.com/repomanager3/configuration/repository-management) in
 detail. Minimal configuration steps are:
 
 - Define 'Name' - e.g. `ansiblegalaxy-proxy`
-- Define URL for 'Remote storage' - e.g. [https://add_format_repo_url/](https://add_format_repo_url/)
+- Define URL for 'Remote storage' - e.g. [https://galaxy.ansible.com/](https://galaxy.ansible.com/)
 - Select a `Blob store` for `Storage`
 
-Using the `ansiblegalaxy` client, you can now download packages from your NXRM AnsibleGalaxy proxy like so:
+Using the `ansible-galaxy` client, you can now download packages from your NXRM AnsibleGalaxy proxy like so:
 
-    $ add client command line example here
+```bash
+ansible-galaxy collection install azure.azcollection -s http://localhost:8081/repository/ansible/
+```
     
-The command above tells ansiblegalaxy to fetch (and install) packages from your NXRM AnsibleGalaxy proxy. The NXRM AnsibleGalaxy proxy will 
-download any missing packages from the remote AnsibleGalaxy repository, and cache the packages on the NXRM AnsibleGalaxy proxy.
-The next time any client requests the same package from your NXRM AnsibleGalaxy proxy, the already cached package will
-be returned to the client.
+The command above tells ansible-galaxy to fetch (and install) packages from your NXRM Ansible Galaxy proxy. The NXRM Ansible Galaxy proxy will download any missing packages from the remote Ansible Galaxy repository, and cache the packages on the NXRM Ansible Galaxy proxy. The next time any client requests the same package from your NXRM Ansible Galaxy proxy, the already cached package will be returned to the client.

--- a/docs/ansiblegalaxy_user_documentation.md
+++ b/docs/ansiblegalaxy_user_documentation.md
@@ -19,10 +19,13 @@
 
 Full documentation on installing `ansible-galaxy` can be found on [the Ansible Galaxy project website](https://docs.ansible.com/ansible/latest/galaxy/user_guide.html).
 
-
 You can create a proxy repository in Nexus Repository Manager (NXRM) that will cache packages from a remote Ansible Galaxy repository, like
 [https://galaxy.ansible.com/](https://galaxy.ansible.com/). Then, you can make the `ansible-galaxy` client use your Nexus Repository Proxy 
 instead of the remote repository.
+
+### Installation
+
+See [installing the plugin](../readme.md#installing-the-plugin).
 
 ### Repository configuration
  

--- a/nexus-repository-ansiblegalaxy-it/pom.xml
+++ b/nexus-repository-ansiblegalaxy-it/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.sonatype.nexus.plugins</groupId>
     <artifactId>nexus-repository-ansiblegalaxy-parent</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
+    <version>0.1.0</version>
   </parent>
 
   <artifactId>nexus-repository-ansiblegalaxy-it</artifactId>

--- a/nexus-repository-ansiblegalaxy-it/src/test/java/org/sonatype/nexus/plugins/ansiblegalaxy/internal/AnsibleGalaxyClient.java
+++ b/nexus-repository-ansiblegalaxy-it/src/test/java/org/sonatype/nexus/plugins/ansiblegalaxy/internal/AnsibleGalaxyClient.java
@@ -22,9 +22,10 @@ import org.apache.http.impl.client.CloseableHttpClient;
 public class AnsibleGalaxyClient
     extends FormatClientSupport
 {
-  public AnsibleGalaxyClient(final CloseableHttpClient httpClient,
-                     final HttpClientContext httpClientContext,
-                     final URI repositoryBaseUri)
+  public AnsibleGalaxyClient(
+      final CloseableHttpClient httpClient,
+      final HttpClientContext httpClientContext,
+      final URI repositoryBaseUri)
   {
     super(httpClient, httpClientContext, repositoryBaseUri);
   }

--- a/nexus-repository-ansiblegalaxy-it/src/test/java/org/sonatype/nexus/plugins/ansiblegalaxy/internal/AnsibleGalaxyITSupport.java
+++ b/nexus-repository-ansiblegalaxy-it/src/test/java/org/sonatype/nexus/plugins/ansiblegalaxy/internal/AnsibleGalaxyITSupport.java
@@ -48,10 +48,6 @@ public class AnsibleGalaxyITSupport
   }
 
   protected AnsibleGalaxyClient ansiblegalaxyClient(final URL repositoryUrl) throws Exception {
-    return new AnsibleGalaxyClient(
-        clientBuilder(repositoryUrl).build(),
-        clientContext(),
-        repositoryUrl.toURI()
-    );
+    return new AnsibleGalaxyClient(clientBuilder(repositoryUrl).build(), clientContext(), repositoryUrl.toURI());
   }
 }

--- a/nexus-repository-ansiblegalaxy-it/src/test/java/org/sonatype/nexus/plugins/ansiblegalaxy/internal/AnsibleGalaxyProxyIT.java
+++ b/nexus-repository-ansiblegalaxy-it/src/test/java/org/sonatype/nexus/plugins/ansiblegalaxy/internal/AnsibleGalaxyProxyIT.java
@@ -28,14 +28,12 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.sonatype.goodies.httpfixture.server.fluent.Behaviours.content;
 import static org.sonatype.goodies.httpfixture.server.fluent.Behaviours.error;
-import static org.sonatype.nexus.plugins.ansiblegalaxy.internal.util.AnsibleGalaxyPathUtils.PACKAGE_FILENAME;
 import static org.sonatype.nexus.testsuite.testsupport.FormatClientSupport.status;
 
 public class AnsibleGalaxyProxyIT
     extends AnsibleGalaxyITSupport
 {
-  // @todo Change test path for your format
-  private static final String TEST_PATH = "some/valid/path/for/your/remote/" + PACKAGE_FILENAME;
+  private static final String TEST_PATH = "api/v2/collections/azure/azcollection/versions/";
 
   private AnsibleGalaxyClient proxyClient;
 
@@ -43,17 +41,13 @@ public class AnsibleGalaxyProxyIT
 
   @Configuration
   public static Option[] configureNexus() {
-    return NexusPaxExamSupport.options(
-        NexusITSupport.configureNexusBase(),
-        nexusFeature("org.sonatype.nexus.plugins", "nexus-repository-ansiblegalaxy")
-    );
+    return NexusPaxExamSupport.options(NexusITSupport.configureNexusBase(),
+        nexusFeature("org.sonatype.nexus.plugins", "nexus-repository-ansiblegalaxy"));
   }
 
   @Test
   public void unresponsiveRemoteProduces404() throws Exception {
-    Server server = Server.withPort(0).serve("/*")
-        .withBehaviours(error(HttpStatus.NOT_FOUND))
-        .start();
+    Server server = Server.withPort(0).serve("/*").withBehaviours(error(HttpStatus.NOT_FOUND)).start();
     try {
       proxyRepo = repos.createAnsibleGalaxyProxy("ansiblegalaxy-test-proxy-notfound", server.getUrl().toExternalForm());
       proxyClient = ansiblegalaxyClient(proxyRepo);
@@ -66,9 +60,7 @@ public class AnsibleGalaxyProxyIT
 
   @Test
   public void retrieveAnsibleGalaxyWhenRemoteOffline() throws Exception {
-    Server server = Server.withPort(0).serve("/*")
-        .withBehaviours(content("Response"))
-        .start();
+    Server server = Server.withPort(0).serve("/*").withBehaviours(content("Response")).start();
     try {
       proxyRepo = repos.createAnsibleGalaxyProxy("ansiblegalaxy-test-proxy-offline", server.getUrl().toExternalForm());
       proxyClient = ansiblegalaxyClient(proxyRepo);

--- a/nexus-repository-ansiblegalaxy-it/src/test/java/org/sonatype/nexus/plugins/ansiblegalaxy/internal/fixtures/AnsibleGalaxyRepoRecipes.groovy
+++ b/nexus-repository-ansiblegalaxy-it/src/test/java/org/sonatype/nexus/plugins/ansiblegalaxy/internal/fixtures/AnsibleGalaxyRepoRecipes.groovy
@@ -26,17 +26,14 @@ import groovy.transform.CompileStatic
  */
 @CompileStatic
 trait AnsibleGalaxyRepoRecipes
-    extends ConfigurationRecipes
-{
+extends ConfigurationRecipes {
   @Nonnull
-  Repository createAnsibleGalaxyProxy(final String name, final String remoteUrl)
-  {
+  Repository createAnsibleGalaxyProxy(final String name, final String remoteUrl) {
     createRepository(createProxy(name, 'ansiblegalaxy-proxy', remoteUrl))
   }
 
   @Nonnull
-  Repository createRHosted(final String name)
-  {
+  Repository createAnsibleGalaxyHosted(final String name) {
     createRepository(createHosted(name, 'ansiblegalaxy-hosted'))
   }
 

--- a/nexus-repository-ansiblegalaxy-it/src/test/java/org/sonatype/nexus/plugins/ansiblegalaxy/internal/fixtures/RepositoryRuleAnsibleGalaxy.groovy
+++ b/nexus-repository-ansiblegalaxy-it/src/test/java/org/sonatype/nexus/plugins/ansiblegalaxy/internal/fixtures/RepositoryRuleAnsibleGalaxy.groovy
@@ -18,9 +18,8 @@ import org.sonatype.nexus.repository.manager.RepositoryManager
 import org.sonatype.nexus.testsuite.testsupport.fixtures.RepositoryRule
 
 class RepositoryRuleAnsibleGalaxy
-    extends RepositoryRule
-    implements AnsibleGalaxyRepoRecipes
-{
+extends RepositoryRule
+implements AnsibleGalaxyRepoRecipes {
   RepositoryRuleAnsibleGalaxy(final Provider<RepositoryManager> repositoryManagerProvider) {
     super(repositoryManagerProvider)
   }

--- a/nexus-repository-ansiblegalaxy/pom.xml
+++ b/nexus-repository-ansiblegalaxy/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.sonatype.nexus.plugins</groupId>
     <artifactId>nexus-repository-ansiblegalaxy-parent</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
+    <version>0.1.0</version>
   </parent>
 
   <artifactId>nexus-repository-ansiblegalaxy</artifactId>

--- a/nexus-repository-ansiblegalaxy/src/main/java/org/sonatype/nexus/plugins/ansiblegalaxy/AnsibleGalaxyFormat.java
+++ b/nexus-repository-ansiblegalaxy/src/main/java/org/sonatype/nexus/plugins/ansiblegalaxy/AnsibleGalaxyFormat.java
@@ -10,26 +10,24 @@
  * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
  * Eclipse Foundation. All other trademarks are the property of their respective owners.
  */
-package org.sonatype.nexus.plugins.ansiblegalaxy.internal.security;
+package org.sonatype.nexus.plugins.ansiblegalaxy;
 
-import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;
 
-import org.sonatype.nexus.plugins.ansiblegalaxy.AnsibleGalaxyFormat;
 import org.sonatype.nexus.repository.Format;
-import org.sonatype.nexus.repository.security.RepositoryFormatSecurityContributor;
 
 /**
- * AnsibleGalaxy format security resource.
+ * AnsibleGalaxy repository format.
  */
-@Named
+@Named(AnsibleGalaxyFormat.NAME)
 @Singleton
-public class AnsibleGalaxyFormatSecurityContributor
-    extends RepositoryFormatSecurityContributor
+public class AnsibleGalaxyFormat
+    extends Format
 {
-  @Inject
-  public AnsibleGalaxyFormatSecurityContributor(@Named(AnsibleGalaxyFormat.NAME) final Format format) {
-    super(format);
+  public static final String NAME = "ansiblegalaxy";
+
+  public AnsibleGalaxyFormat() {
+    super(NAME);
   }
 }

--- a/nexus-repository-ansiblegalaxy/src/main/java/org/sonatype/nexus/plugins/ansiblegalaxy/AssetKind.java
+++ b/nexus-repository-ansiblegalaxy/src/main/java/org/sonatype/nexus/plugins/ansiblegalaxy/AssetKind.java
@@ -16,6 +16,7 @@ import javax.annotation.Nonnull;
 
 import org.sonatype.nexus.repository.cache.CacheControllerHolder.CacheType;
 
+import static org.sonatype.nexus.repository.cache.CacheControllerHolder.CONTENT;
 import static org.sonatype.nexus.repository.cache.CacheControllerHolder.METADATA;
 
 /**
@@ -25,7 +26,8 @@ public enum AssetKind
 {
   API_INTERNALS(METADATA),
   VERSION_LIST(METADATA),
-  VERSION(METADATA);
+  VERSION(METADATA),
+  ARTIFACT(CONTENT);
 
   private final CacheType cacheType;
 

--- a/nexus-repository-ansiblegalaxy/src/main/java/org/sonatype/nexus/plugins/ansiblegalaxy/AssetKind.java
+++ b/nexus-repository-ansiblegalaxy/src/main/java/org/sonatype/nexus/plugins/ansiblegalaxy/AssetKind.java
@@ -10,24 +10,31 @@
  * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
  * Eclipse Foundation. All other trademarks are the property of their respective owners.
  */
-package org.sonatype.nexus.plugins.ansiblegalaxy.internal;
+package org.sonatype.nexus.plugins.ansiblegalaxy;
 
-import javax.inject.Named;
-import javax.inject.Singleton;
+import javax.annotation.Nonnull;
 
-import org.sonatype.nexus.repository.Format;
+import org.sonatype.nexus.repository.cache.CacheControllerHolder.CacheType;
+
+import static org.sonatype.nexus.repository.cache.CacheControllerHolder.METADATA;
 
 /**
- * AnsibleGalaxy repository format.
+ * Asset kinds for AnsibleGalaxy.
  */
-@Named(AnsibleGalaxyFormat.NAME)
-@Singleton
-public class AnsibleGalaxyFormat
-    extends Format
+public enum AssetKind
 {
-  public static final String NAME = "ansiblegalaxy";
+  API_INTERNALS(METADATA),
+  VERSION_LIST(METADATA),
+  VERSION(METADATA);
 
-  public AnsibleGalaxyFormat() {
-    super(NAME);
+  private final CacheType cacheType;
+
+  AssetKind(final CacheType cacheType) {
+    this.cacheType = cacheType;
+  }
+
+  @Nonnull
+  public CacheType getCacheType() {
+    return cacheType;
   }
 }

--- a/nexus-repository-ansiblegalaxy/src/main/java/org/sonatype/nexus/plugins/ansiblegalaxy/internal/AnsibleGalaxyRecipeSupport.groovy
+++ b/nexus-repository-ansiblegalaxy/src/main/java/org/sonatype/nexus/plugins/ansiblegalaxy/internal/AnsibleGalaxyRecipeSupport.groovy
@@ -161,4 +161,18 @@ extends RecipeSupport {
         }
         )
   }
+
+  static Matcher artifactMatcher() {
+    LogicMatchers.and(
+        new ActionMatcher(GET, HEAD),
+        new TokenMatcher("/download/{author}-{module}-{version}.tar.gz"),
+        new Matcher() {
+          @Override
+          boolean matches(final Context context) {
+            context.attributes.set(AssetKind.class, AssetKind.ARTIFACT)
+            return true
+          }
+        }
+        )
+  }
 }

--- a/nexus-repository-ansiblegalaxy/src/main/java/org/sonatype/nexus/plugins/ansiblegalaxy/internal/AnsibleGalaxyRecipeSupport.groovy
+++ b/nexus-repository-ansiblegalaxy/src/main/java/org/sonatype/nexus/plugins/ansiblegalaxy/internal/AnsibleGalaxyRecipeSupport.groovy
@@ -1,12 +1,15 @@
 /*
  * Sonatype Nexus (TM) Open Source Version
  * Copyright (c) 2020-present Sonatype, Inc.
- * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype
+ * .com/products/nexus/oss/attributions.
  *
- * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License
+ * Version 1.0,
  * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
  *
- * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are
+ * trademarks
  * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
  * Eclipse Foundation. All other trademarks are the property of their respective owners.
  */
@@ -15,8 +18,8 @@ package org.sonatype.nexus.plugins.ansiblegalaxy.internal
 import javax.inject.Inject
 import javax.inject.Provider
 
+import org.sonatype.nexus.plugins.ansiblegalaxy.AssetKind
 import org.sonatype.nexus.plugins.ansiblegalaxy.internal.security.AnsibleGalaxySecurityFacet
-
 import org.sonatype.nexus.repository.Format
 import org.sonatype.nexus.repository.RecipeSupport
 import org.sonatype.nexus.repository.Type
@@ -26,6 +29,7 @@ import org.sonatype.nexus.repository.cache.NegativeCacheHandler
 import org.sonatype.nexus.repository.http.PartialFetchHandler
 import org.sonatype.nexus.repository.httpclient.HttpClientFacet
 import org.sonatype.nexus.repository.purge.PurgeUnusedFacet
+import org.sonatype.nexus.repository.routing.RoutingRuleHandler
 import org.sonatype.nexus.repository.search.SearchFacet
 import org.sonatype.nexus.repository.security.SecurityHandler
 import org.sonatype.nexus.repository.storage.DefaultComponentMaintenanceImpl
@@ -38,13 +42,12 @@ import org.sonatype.nexus.repository.view.handlers.ConditionalRequestHandler
 import org.sonatype.nexus.repository.view.handlers.ContentHeadersHandler
 import org.sonatype.nexus.repository.view.handlers.ExceptionHandler
 import org.sonatype.nexus.repository.view.handlers.HandlerContributor
+import org.sonatype.nexus.repository.view.handlers.LastDownloadedHandler
 import org.sonatype.nexus.repository.view.handlers.TimingHandler
 import org.sonatype.nexus.repository.view.matchers.ActionMatcher
 import org.sonatype.nexus.repository.view.matchers.logic.LogicMatchers
 import org.sonatype.nexus.repository.view.matchers.token.TokenMatcher
 
-import static org.sonatype.nexus.plugins.ansiblegalaxy.internal.util.AnsibleGalaxyPathUtils.ASSET_FILENAME
-import static org.sonatype.nexus.plugins.ansiblegalaxy.internal.util.AnsibleGalaxyPathUtils.PACKAGE_FILENAME
 import static org.sonatype.nexus.repository.http.HttpMethods.GET
 import static org.sonatype.nexus.repository.http.HttpMethods.HEAD
 
@@ -52,8 +55,7 @@ import static org.sonatype.nexus.repository.http.HttpMethods.HEAD
  * Support for AnsibleGalaxy recipes.
  */
 abstract class AnsibleGalaxyRecipeSupport
-    extends RecipeSupport
-{
+extends RecipeSupport {
   @Inject
   Provider<AnsibleGalaxySecurityFacet> securityFacet
 
@@ -108,34 +110,55 @@ abstract class AnsibleGalaxyRecipeSupport
   @Inject
   NegativeCacheHandler negativeCacheHandler
 
+  @Inject
+  RoutingRuleHandler routingRuleHandler
+
+  @Inject
+  LastDownloadedHandler lastDownloadedHandler
+
   protected AnsibleGalaxyRecipeSupport(final Type type, final Format format) {
     super(type, format)
   }
 
-  // @todo Add/change matcher methods here
-
-  static Matcher packageAnsibleGalaxyMatcher() {
-    buildTokenMatcherForPatternAndAssetKind("/{myTokenName:.+}/${PACKAGE_FILENAME}", AssetKind.PACKAGES, GET, HEAD)
-  }
-
-  static Matcher assetAnsibleGalaxyMatcher() {
-    buildTokenMatcherForPatternAndAssetKind("/{myTokenName:.+}/${ASSET_FILENAME}", AssetKind.ARCHIVE, GET, HEAD)
-  }
-
-  static Matcher buildTokenMatcherForPatternAndAssetKind(final String pattern,
-                                                         final AssetKind assetKind,
-                                                         final String... actions) {
+  static Matcher apiInternalsMatcher() {
     LogicMatchers.and(
-        new ActionMatcher(actions),
-        new TokenMatcher(pattern),
+        new ActionMatcher(GET, HEAD),
+        new TokenMatcher("/api"),
         new Matcher() {
           @Override
           boolean matches(final Context context) {
-            context.attributes.set(AssetKind.class, assetKind)
+            context.attributes.set(AssetKind.class, AssetKind.API_INTERNALS)
             return true
           }
         }
-    )
+        )
   }
 
+  static Matcher versionListMatcher() {
+    LogicMatchers.and(
+        new ActionMatcher(GET, HEAD),
+        new TokenMatcher("/api/{apiversion}/collections/{author}/{module}/versions/"),
+        new Matcher() {
+          @Override
+          boolean matches(final Context context) {
+            context.attributes.set(AssetKind.class, AssetKind.VERSION_LIST)
+            return true
+          }
+        }
+        )
+  }
+
+  static Matcher versionMatcher() {
+    LogicMatchers.and(
+        new ActionMatcher(GET, HEAD),
+        new TokenMatcher("/api/{apiversion}/collections/{author}/{module}/versions/{version}/"),
+        new Matcher() {
+          @Override
+          boolean matches(final Context context) {
+            context.attributes.set(AssetKind.class, AssetKind.VERSION)
+            return true
+          }
+        }
+        )
+  }
 }

--- a/nexus-repository-ansiblegalaxy/src/main/java/org/sonatype/nexus/plugins/ansiblegalaxy/internal/AnsibleGalaxyRecipeSupport.groovy
+++ b/nexus-repository-ansiblegalaxy/src/main/java/org/sonatype/nexus/plugins/ansiblegalaxy/internal/AnsibleGalaxyRecipeSupport.groovy
@@ -20,6 +20,7 @@ import javax.inject.Provider
 
 import org.sonatype.nexus.plugins.ansiblegalaxy.AssetKind
 import org.sonatype.nexus.plugins.ansiblegalaxy.internal.security.AnsibleGalaxySecurityFacet
+import org.sonatype.nexus.plugins.ansiblegalaxy.internal.util.QueryTokenMatcher
 import org.sonatype.nexus.repository.Format
 import org.sonatype.nexus.repository.RecipeSupport
 import org.sonatype.nexus.repository.Type
@@ -137,7 +138,10 @@ extends RecipeSupport {
   static Matcher versionListMatcher() {
     LogicMatchers.and(
         new ActionMatcher(GET, HEAD),
-        new TokenMatcher("/api/{apiversion}/collections/{author}/{module}/versions/"),
+        LogicMatchers.or(
+        new QueryTokenMatcher("/api/{apiversion}/collections/{author}/{module}/versions/?page={pagenum}"),
+        new TokenMatcher("/api/{apiversion}/collections/{author}/{module}/versions/")
+        ),
         new Matcher() {
           @Override
           boolean matches(final Context context) {

--- a/nexus-repository-ansiblegalaxy/src/main/java/org/sonatype/nexus/plugins/ansiblegalaxy/internal/metadata/AnsibleGalaxyAttributes.java
+++ b/nexus-repository-ansiblegalaxy/src/main/java/org/sonatype/nexus/plugins/ansiblegalaxy/internal/metadata/AnsibleGalaxyAttributes.java
@@ -1,6 +1,6 @@
 /*
  * Sonatype Nexus (TM) Open Source Version
- * Copyright (c) 2020-present Sonatype, Inc.
+ * Copyright (c) 2008-present Sonatype, Inc.
  * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
  *
  * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
@@ -10,32 +10,40 @@
  * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
  * Eclipse Foundation. All other trademarks are the property of their respective owners.
  */
-package org.sonatype.nexus.plugins.ansiblegalaxy.internal;
-
-import javax.annotation.Nonnull;
-
-import org.sonatype.nexus.repository.cache.CacheControllerHolder.CacheType;
-
-import static org.sonatype.nexus.repository.cache.CacheControllerHolder.CONTENT;
-import static org.sonatype.nexus.repository.cache.CacheControllerHolder.METADATA;
+package org.sonatype.nexus.plugins.ansiblegalaxy.internal.metadata;
 
 /**
- * Asset kinds for AnsibleGalaxy.
+ * Object for storing AnsibleGalaxy specific attributes.
  */
-public enum AssetKind
+public final class AnsibleGalaxyAttributes
 {
-  // @todo Change these enums as needed for this format
-  PACKAGES(METADATA),
-  ARCHIVE(CONTENT);
+  private String author;
 
-  private final CacheType cacheType;
+  private String module;
 
-  AssetKind(final CacheType cacheType) {
-    this.cacheType = cacheType;
+  private String version;
+
+  public String getAuthor() {
+    return author;
   }
 
-  @Nonnull
-  public CacheType getCacheType() {
-    return cacheType;
+  public void setAuthor(final String author) {
+    this.author = author;
+  }
+
+  public String getModule() {
+    return module;
+  }
+
+  public void setModule(final String module) {
+    this.module = module;
+  }
+
+  public String getVersion() {
+    return version;
+  }
+
+  public void setVersion(final String version) {
+    this.version = version;
   }
 }

--- a/nexus-repository-ansiblegalaxy/src/main/java/org/sonatype/nexus/plugins/ansiblegalaxy/internal/metadata/AnsibleGalaxyAttributes.java
+++ b/nexus-repository-ansiblegalaxy/src/main/java/org/sonatype/nexus/plugins/ansiblegalaxy/internal/metadata/AnsibleGalaxyAttributes.java
@@ -17,33 +17,27 @@ package org.sonatype.nexus.plugins.ansiblegalaxy.internal.metadata;
  */
 public final class AnsibleGalaxyAttributes
 {
-  private String author;
+  private final String author;
 
-  private String module;
+  private final String module;
 
-  private String version;
+  private final String version;
+
+  public AnsibleGalaxyAttributes(String author, String module, String version) {
+    this.author = author;
+    this.module = module;
+    this.version = version;
+  }
 
   public String getAuthor() {
     return author;
-  }
-
-  public void setAuthor(final String author) {
-    this.author = author;
   }
 
   public String getModule() {
     return module;
   }
 
-  public void setModule(final String module) {
-    this.module = module;
-  }
-
   public String getVersion() {
     return version;
-  }
-
-  public void setVersion(final String version) {
-    this.version = version;
   }
 }

--- a/nexus-repository-ansiblegalaxy/src/main/java/org/sonatype/nexus/plugins/ansiblegalaxy/internal/proxy/AnsibleGalaxyProxyFacetImpl.java
+++ b/nexus-repository-ansiblegalaxy/src/main/java/org/sonatype/nexus/plugins/ansiblegalaxy/internal/proxy/AnsibleGalaxyProxyFacetImpl.java
@@ -200,6 +200,8 @@ public class AnsibleGalaxyProxyFacetImpl
 
   @Override
   protected String getUrl(@Nonnull final Context context) {
-    return context.getRequest().getPath().substring(1);
+    String url = AnsibleGalaxyPathUtils.getUri(context.getRequest()).substring(1);
+    log.debug("url: {}", url);
+    return url;
   }
 }

--- a/nexus-repository-ansiblegalaxy/src/main/java/org/sonatype/nexus/plugins/ansiblegalaxy/internal/proxy/AnsibleGalaxyProxyFacetImpl.java
+++ b/nexus-repository-ansiblegalaxy/src/main/java/org/sonatype/nexus/plugins/ansiblegalaxy/internal/proxy/AnsibleGalaxyProxyFacetImpl.java
@@ -19,7 +19,8 @@ import javax.annotation.Nullable;
 import javax.inject.Inject;
 import javax.inject.Named;
 
-import org.sonatype.nexus.plugins.ansiblegalaxy.internal.AssetKind;
+import org.sonatype.goodies.common.Loggers;
+import org.sonatype.nexus.plugins.ansiblegalaxy.AssetKind;
 import org.sonatype.nexus.plugins.ansiblegalaxy.internal.util.AnsibleGalaxyDataAccess;
 import org.sonatype.nexus.plugins.ansiblegalaxy.internal.util.AnsibleGalaxyPathUtils;
 import org.sonatype.nexus.repository.cache.CacheInfo;
@@ -27,11 +28,8 @@ import org.sonatype.nexus.repository.config.Configuration;
 import org.sonatype.nexus.repository.proxy.ProxyFacet;
 import org.sonatype.nexus.repository.proxy.ProxyFacetSupport;
 import org.sonatype.nexus.repository.storage.Asset;
-import org.sonatype.nexus.repository.storage.Bucket;
-import org.sonatype.nexus.repository.storage.Component;
 import org.sonatype.nexus.repository.storage.StorageFacet;
 import org.sonatype.nexus.repository.storage.StorageTx;
-import org.sonatype.nexus.repository.transaction.TransactionalStoreBlob;
 import org.sonatype.nexus.repository.transaction.TransactionalTouchBlob;
 import org.sonatype.nexus.repository.transaction.TransactionalTouchMetadata;
 import org.sonatype.nexus.repository.view.Content;
@@ -40,10 +38,10 @@ import org.sonatype.nexus.repository.view.matchers.token.TokenMatcher;
 import org.sonatype.nexus.repository.view.payloads.TempBlob;
 import org.sonatype.nexus.transaction.UnitOfWork;
 
+import org.slf4j.Logger;
+
 import static com.google.common.base.Preconditions.checkNotNull;
-import static org.sonatype.nexus.plugins.ansiblegalaxy.internal.util.AnsibleGalaxyPathUtils.ASSET_FILENAME;
-import static org.sonatype.nexus.plugins.ansiblegalaxy.internal.util.AnsibleGalaxyPathUtils.PACKAGE_FILENAME;
-import static org.sonatype.nexus.repository.storage.AssetEntityAdapter.P_ASSET_KIND;
+import static org.sonatype.nexus.plugins.ansiblegalaxy.internal.util.AnsibleGalaxyDataAccess.HASH_ALGORITHMS;
 
 /**
  * AnsibleGalaxy {@link ProxyFacet} implementation.
@@ -55,13 +53,16 @@ public class AnsibleGalaxyProxyFacetImpl
     extends ProxyFacetSupport
     implements AnsibleGalaxyProxyFacet
 {
-  private AnsibleGalaxyPathUtils ansiblegalaxyPathUtils;
+  private final Logger log = Loggers.getLogger(getClass());
 
-  private AnsibleGalaxyDataAccess ansiblegalaxyDataAccess;
+  private final AnsibleGalaxyPathUtils ansiblegalaxyPathUtils;
+
+  private final AnsibleGalaxyDataAccess ansiblegalaxyDataAccess;
 
   @Inject
-  public AnsibleGalaxyProxyFacetImpl(final AnsibleGalaxyPathUtils ansiblegalaxyPathUtils,
-                             final AnsibleGalaxyDataAccess ansiblegalaxyDataAccess)
+  public AnsibleGalaxyProxyFacetImpl(
+      final AnsibleGalaxyPathUtils ansiblegalaxyPathUtils,
+      final AnsibleGalaxyDataAccess ansiblegalaxyDataAccess)
   {
     this.ansiblegalaxyPathUtils = checkNotNull(ansiblegalaxyPathUtils);
     this.ansiblegalaxyDataAccess = checkNotNull(ansiblegalaxyDataAccess);
@@ -77,12 +78,16 @@ public class AnsibleGalaxyProxyFacetImpl
   @Override
   protected Content getCachedContent(final Context context) {
     AssetKind assetKind = context.getAttributes().require(AssetKind.class);
+    if (assetKind.equals(AssetKind.API_INTERNALS)) {
+      return null; // results not stored
+    }
+
     TokenMatcher.State matcherState = ansiblegalaxyPathUtils.matcherState(context);
     switch (assetKind) {
-      case PACKAGES:
-        return getAsset(ansiblegalaxyPathUtils.buildAssetPath(matcherState, PACKAGE_FILENAME));
-      case ARCHIVE:
-        return getAsset(ansiblegalaxyPathUtils.buildAssetPath(matcherState, ASSET_FILENAME));
+      case VERSION_LIST:
+        return getAsset(ansiblegalaxyPathUtils.versionListPath(matcherState));
+      case VERSION:
+        return getAsset(ansiblegalaxyPathUtils.versionPath(matcherState));
       default:
         throw new IllegalStateException("Received an invalid AssetKind of type: " + assetKind.name());
     }
@@ -102,96 +107,52 @@ public class AnsibleGalaxyProxyFacetImpl
   @Override
   protected Content store(final Context context, final Content content) throws IOException {
     AssetKind assetKind = context.getAttributes().require(AssetKind.class);
+    log.info("----- store() assetKind: {}", assetKind.name());
+    log.info("----- store() content: {}", content.toString());
+    if (assetKind.equals(AssetKind.API_INTERNALS)) {
+      return content; // results not stored
+    }
+
     TokenMatcher.State matcherState = ansiblegalaxyPathUtils.matcherState(context);
     switch (assetKind) {
-      case PACKAGES:
-        return putMetadata(content,
-            assetKind,
-            ansiblegalaxyPathUtils.buildAssetPath(matcherState, PACKAGE_FILENAME));
-      case ARCHIVE:
-        return putAnsibleGalaxyPackage(content,
-            assetKind,
-            ansiblegalaxyPathUtils.buildAssetPath(matcherState, ASSET_FILENAME));
+      case VERSION_LIST:
+        return putAsset(content, ansiblegalaxyPathUtils.versionListPath(matcherState), assetKind);
+      case VERSION:
+        return putAsset(content, ansiblegalaxyPathUtils.versionPath(matcherState), assetKind);
       default:
         throw new IllegalStateException("Received an invalid AssetKind of type: " + assetKind.name());
     }
   }
 
-  private Content putAnsibleGalaxyPackage(final Content content,
-                                  final AssetKind assetKind,
-                                  final String assetPath)
-      throws IOException
+  private Content putAsset(
+      final Content content,
+      final String assetPath,
+      final AssetKind assetKind) throws IOException
   {
     StorageFacet storageFacet = facet(StorageFacet.class);
-
-    try (TempBlob tempBlob = storageFacet.createTempBlob(content.openInputStream(), AnsibleGalaxyDataAccess.HASH_ALGORITHMS)) {
-      Component component = findOrCreateComponent(assetPath);
-
-      return findOrCreateAsset(tempBlob, content, assetKind, assetPath, component);
+    try (TempBlob tempBlob = storageFacet.createTempBlob(content.openInputStream(), HASH_ALGORITHMS)) {
+      return ansiblegalaxyDataAccess.maybeCreateAndSaveAsset(getRepository(), assetPath, assetKind, tempBlob, content);
     }
   }
 
-  @TransactionalStoreBlob
-  protected Component findOrCreateComponent(final String assetPath) {
-    StorageTx tx = UnitOfWork.currentTx();
-    Bucket bucket = tx.findBucket(getRepository());
-
-    Component component = ansiblegalaxyDataAccess.findComponent(tx,
-        getRepository(),
-        assetPath);
-
-    if (component == null) {
-      component = tx.createComponent(bucket, getRepository().getFormat())
-          .name(assetPath);
-    }
-    tx.saveComponent(component);
-
-    return component;
-  }
-
-  private Content putMetadata(final Content content,
-                              final AssetKind assetKind,
-                              final String assetPath) throws IOException
-  {
-    StorageFacet storageFacet = facet(StorageFacet.class);
-
-    try (TempBlob tempBlob = storageFacet.createTempBlob(content.openInputStream(), AnsibleGalaxyDataAccess.HASH_ALGORITHMS)) {
-      return findOrCreateAsset(tempBlob, content, assetKind, assetPath, null);
-    }
-  }
-
-  @TransactionalStoreBlob
-  protected Content findOrCreateAsset(final TempBlob tempBlob,
-                                      final Content content,
-                                      final AssetKind assetKind,
-                                      final String assetPath,
-                                      final Component component) throws IOException
-  {
-    StorageTx tx = UnitOfWork.currentTx();
-    Bucket bucket = tx.findBucket(getRepository());
-
-    Asset asset = ansiblegalaxyDataAccess.findAsset(tx, bucket, assetPath);
-
-    if (assetKind.equals(AssetKind.ARCHIVE)) {
-      if (asset == null) {
-        asset = tx.createAsset(bucket, component);
-        asset.name(assetPath);
-        asset.formatAttributes().set(P_ASSET_KIND, assetKind.name());
-      }
-    } else {
-      if (asset == null) {
-        asset = tx.createAsset(bucket, getRepository().getFormat());
-        asset.name(assetPath);
-        asset.formatAttributes().set(P_ASSET_KIND, assetKind.name());
-      }
-    }
-
-    return ansiblegalaxyDataAccess.saveAsset(tx, asset, tempBlob, content);
-  }
+  // private Content putComponent(
+  // final GolangAttributes golangAttributes,
+  // final Content content,
+  // final String assetPath,
+  // final AssetKind assetKind) throws IOException
+  // {
+  // StorageFacet storageFacet = facet(StorageFacet.class);
+  // try (TempBlob tempBlob = storageFacet.createTempBlob(content.openInputStream(), HASH_ALGORITHMS)) {
+  // return ansiblegalaxyDataAccess.maybeCreateAndSaveComponent(getRepository(), golangAttributes, assetPath, tempBlob,
+  // content, assetKind);
+  // }
+  // }
 
   @Override
-  protected void indicateVerified(final Context context, final Content content, final CacheInfo cacheInfo)
-      throws IOException
+  protected void indicateVerified(
+      final Context context,
+      final Content content,
+      final CacheInfo cacheInfo) throws IOException
   {
     setCacheInfo(content, cacheInfo);
   }
@@ -201,9 +162,8 @@ public class AnsibleGalaxyProxyFacetImpl
     StorageTx tx = UnitOfWork.currentTx();
     Asset asset = Content.findAsset(tx, tx.findBucket(getRepository()), content);
     if (asset == null) {
-      log.debug(
-          "Attempting to set cache info for non-existent AnsibleGalaxy asset {}", content.getAttributes().require(Asset.class)
-      );
+      log.debug("Attempting to set cache info for non-existent AnsibleGalaxy asset {}",
+          content.getAttributes().require(Asset.class));
       return;
     }
     log.debug("Updating cacheInfo of {} to {}", asset, cacheInfo);

--- a/nexus-repository-ansiblegalaxy/src/main/java/org/sonatype/nexus/plugins/ansiblegalaxy/internal/proxy/AnsibleGalaxyProxyRecipe.groovy
+++ b/nexus-repository-ansiblegalaxy/src/main/java/org/sonatype/nexus/plugins/ansiblegalaxy/internal/proxy/AnsibleGalaxyProxyRecipe.groovy
@@ -76,7 +76,8 @@ extends AnsibleGalaxyRecipeSupport {
     [
       apiInternalsMatcher(),
       versionListMatcher(),
-      versionMatcher()
+      versionMatcher(),
+      artifactMatcher()
     ].each { matcher ->
       builder.route(new Route.Builder().matcher(matcher)
           .handler(timingHandler)

--- a/nexus-repository-ansiblegalaxy/src/main/java/org/sonatype/nexus/plugins/ansiblegalaxy/internal/security/AnsibleGalaxySecurityFacet.java
+++ b/nexus-repository-ansiblegalaxy/src/main/java/org/sonatype/nexus/plugins/ansiblegalaxy/internal/security/AnsibleGalaxySecurityFacet.java
@@ -15,7 +15,6 @@ package org.sonatype.nexus.plugins.ansiblegalaxy.internal.security;
 import javax.inject.Inject;
 import javax.inject.Named;
 
-import org.sonatype.nexus.repository.config.Configuration;
 import org.sonatype.nexus.repository.security.ContentPermissionChecker;
 import org.sonatype.nexus.repository.security.SecurityFacetSupport;
 import org.sonatype.nexus.repository.security.VariableResolverAdapter;
@@ -28,15 +27,11 @@ public class AnsibleGalaxySecurityFacet
     extends SecurityFacetSupport
 {
   @Inject
-  public AnsibleGalaxySecurityFacet(final AnsibleGalaxyFormatSecurityContributor securityResource,
-                            @Named("simple") final VariableResolverAdapter variableResolverAdapter,
-                            final ContentPermissionChecker contentPermissionChecker)
+  public AnsibleGalaxySecurityFacet(
+      final AnsibleGalaxyFormatSecurityContributor securityResource,
+      @Named("simple") final VariableResolverAdapter variableResolverAdapter,
+      final ContentPermissionChecker contentPermissionChecker)
   {
     super(securityResource, variableResolverAdapter, contentPermissionChecker);
-  }
-
-  @Override
-  protected void doValidate(final Configuration configuration) throws Exception {
-    super.doValidate(configuration);
   }
 }

--- a/nexus-repository-ansiblegalaxy/src/main/java/org/sonatype/nexus/plugins/ansiblegalaxy/internal/util/AnsibleGalaxyPathUtils.java
+++ b/nexus-repository-ansiblegalaxy/src/main/java/org/sonatype/nexus/plugins/ansiblegalaxy/internal/util/AnsibleGalaxyPathUtils.java
@@ -22,27 +22,34 @@ import org.sonatype.nexus.repository.view.matchers.token.TokenMatcher.State;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
- * @since 0.0.1
+ * Utility methods for working with AnsibleGalaxy routes and paths.
  */
 @Named
 @Singleton
 public class AnsibleGalaxyPathUtils
 {
-  // @todo Change this to a valid filename for your format
-  public static final String PACKAGE_FILENAME = "myPackageFilename.txt";
+  /**
+   * Returns the author from a {@link TokenMatcher.State}.
+   */
+  public String author(final TokenMatcher.State state) {
+    return match(state, "author");
+  }
 
-  // @todo Change this to a valid filename for your format
-  public static final String ASSET_FILENAME = "myAssetFilename.fil";
+  public String module(final TokenMatcher.State state) {
+    return match(state, "module");
+  }
+
+  public String version(final TokenMatcher.State state) {
+    return match(state, "version");
+  }
 
   public TokenMatcher.State matcherState(final Context context) {
     return context.getAttributes().require(TokenMatcher.State.class);
   }
 
-  // @todo Change this to a valid token for your format
-  public String myToken(final TokenMatcher.State state) {
-    return match(state, "myTokenName");
-  }
-
+  /**
+   * Utility method encapsulating getting a particular token by name from a matcher, including preconditions.
+   */
   private String match(final TokenMatcher.State state, final String name) {
     checkNotNull(state);
     String result = state.getTokens().get(name);
@@ -50,7 +57,18 @@ public class AnsibleGalaxyPathUtils
     return result;
   }
 
-  public String buildAssetPath(final State matcherState, final String assetName) {
-    return String.format("/%s/%s", myToken(matcherState), assetName);
+  public String versionListPath(final State matcherState) {
+    String author = author(matcherState);
+    String module = module(matcherState);
+
+    return String.format("%s/%s/versions", author, module);
+  }
+
+  public String versionPath(final State matcherState) {
+    String author = author(matcherState);
+    String module = module(matcherState);
+    String version = version(matcherState);
+
+    return String.format("%s/%s/%s", author, module, version);
   }
 }

--- a/nexus-repository-ansiblegalaxy/src/main/java/org/sonatype/nexus/plugins/ansiblegalaxy/internal/util/AnsibleGalaxyPathUtils.java
+++ b/nexus-repository-ansiblegalaxy/src/main/java/org/sonatype/nexus/plugins/ansiblegalaxy/internal/util/AnsibleGalaxyPathUtils.java
@@ -15,6 +15,7 @@ package org.sonatype.nexus.plugins.ansiblegalaxy.internal.util;
 import javax.inject.Named;
 import javax.inject.Singleton;
 
+import org.sonatype.nexus.plugins.ansiblegalaxy.internal.metadata.AnsibleGalaxyAttributes;
 import org.sonatype.nexus.repository.view.Context;
 import org.sonatype.nexus.repository.view.matchers.token.TokenMatcher;
 import org.sonatype.nexus.repository.view.matchers.token.TokenMatcher.State;
@@ -69,6 +70,18 @@ public class AnsibleGalaxyPathUtils
     String module = module(matcherState);
     String version = version(matcherState);
 
-    return String.format("%s/%s/%s", author, module, version);
+    return String.format("%s/%s/%s/version", author, module, version);
+  }
+
+  public String artifactPath(final State matcherState) {
+    String author = author(matcherState);
+    String module = module(matcherState);
+    String version = version(matcherState);
+
+    return String.format("%s/%s/%s/artifact", author, module, version);
+  }
+
+  public AnsibleGalaxyAttributes getAttributesFromMatcherState(final TokenMatcher.State state) {
+    return new AnsibleGalaxyAttributes(author(state), module(state), version(state));
   }
 }

--- a/nexus-repository-ansiblegalaxy/src/main/java/org/sonatype/nexus/plugins/ansiblegalaxy/internal/util/QueryTokenMatcher.java
+++ b/nexus-repository-ansiblegalaxy/src/main/java/org/sonatype/nexus/plugins/ansiblegalaxy/internal/util/QueryTokenMatcher.java
@@ -1,0 +1,64 @@
+package org.sonatype.nexus.plugins.ansiblegalaxy.internal.util;
+
+import java.util.Map;
+
+import org.sonatype.nexus.repository.view.Context;
+import org.sonatype.nexus.repository.view.Matcher;
+import org.sonatype.nexus.repository.view.Request;
+import org.sonatype.nexus.repository.view.matchers.token.TokenMatcher;
+import org.sonatype.nexus.repository.view.matchers.token.TokenParser;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/**
+ * A {@link Matcher} that examines the {@link Request#getPath() request path} and {@link Request#getParameters() request
+ * parameters} and attempts to parse it using the
+ * {@link TokenParser}.
+ *
+ * If there is a match, the tokens are stored in the context under key {@link TokenMatcher.State}.
+ *
+ * @see {@link TokenMatcher}: examines only request path and not parameters.
+ */
+public class QueryTokenMatcher
+    extends TokenMatcher
+{
+
+  private final TokenParser parser;
+
+  private final String pattern;
+
+  public QueryTokenMatcher(String pattern) {
+    super(pattern);
+    this.pattern = checkNotNull(pattern);
+    this.parser = new TokenParser(pattern);
+  }
+
+  @Override
+  public boolean matches(final Context context) {
+    checkNotNull(context);
+
+    String uri = AnsibleGalaxyPathUtils.getUri(context.getRequest());
+    log.debug("Matching: {}~={}", uri, parser);
+    final Map<String, String> tokens = parser.parse(uri);
+    if (tokens == null) {
+      // There was no match.
+      return false;
+    }
+
+    // matched expose tokens in context
+    context.getAttributes().set(State.class, new State()
+    {
+      @Override
+      public String pattern() {
+        return pattern;
+      }
+
+      @Override
+      public Map<String, String> getTokens() {
+        return tokens;
+      }
+    });
+    return true;
+  }
+
+}

--- a/nexus-repository-ansiblegalaxy/src/test/java/org/sonatype/nexus/plugins/ansiblegalaxy/internal/AnsibleGalaxyFormatTest.java
+++ b/nexus-repository-ansiblegalaxy/src/test/java/org/sonatype/nexus/plugins/ansiblegalaxy/internal/AnsibleGalaxyFormatTest.java
@@ -12,6 +12,8 @@
  */
 package org.sonatype.nexus.plugins.ansiblegalaxy.internal;
 
+import org.sonatype.nexus.plugins.ansiblegalaxy.AnsibleGalaxyFormat;
+
 import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.equalTo;

--- a/nexus-repository-ansiblegalaxy/src/test/java/org/sonatype/nexus/plugins/ansiblegalaxy/internal/util/AnsibleGalaxyPathUtilsTest.java
+++ b/nexus-repository-ansiblegalaxy/src/test/java/org/sonatype/nexus/plugins/ansiblegalaxy/internal/util/AnsibleGalaxyPathUtilsTest.java
@@ -56,6 +56,13 @@ public class AnsibleGalaxyPathUtilsTest
   public void versionPath() {
     String result = underTest.versionPath(state);
 
-    assertThat(result, is(equalTo("azure/azcollection/1.2.0")));
+    assertThat(result, is(equalTo("azure/azcollection/1.2.0/version")));
+  }
+
+  @Test
+  public void artifactPath() {
+    String result = underTest.artifactPath(state);
+
+    assertThat(result, is(equalTo("azure/azcollection/1.2.0/artifact")));
   }
 }

--- a/nexus-repository-ansiblegalaxy/src/test/java/org/sonatype/nexus/plugins/ansiblegalaxy/internal/util/AnsibleGalaxyPathUtilsTest.java
+++ b/nexus-repository-ansiblegalaxy/src/test/java/org/sonatype/nexus/plugins/ansiblegalaxy/internal/util/AnsibleGalaxyPathUtilsTest.java
@@ -35,26 +35,27 @@ public class AnsibleGalaxyPathUtilsTest
   @Mock
   TokenMatcher.State state;
 
-  private Map<String, String> tokens;
-
   @Before
   public void setUp() {
     underTest = new AnsibleGalaxyPathUtils();
-    tokens = setupTokens("myTokenValue");
+    Map<String, String> tokens = new HashMap<>();
+    tokens.put("author", "azure");
+    tokens.put("module", "azcollection");
+    tokens.put("version", "1.2.0");
     when(state.getTokens()).thenReturn(tokens);
   }
 
   @Test
-  public void buildAssetPath() {
-    String result = underTest.buildAssetPath(state, AnsibleGalaxyPathUtils.PACKAGE_FILENAME);
+  public void versionListPath() {
+    String result = underTest.versionListPath(state);
 
-    assertThat(result, is(equalTo("/myTokenValue/myPackageFilename.txt")));
+    assertThat(result, is(equalTo("azure/azcollection/versions")));
   }
 
-  private Map<String, String> setupTokens(final String tokenValue) {
-    Map<String, String> tokens = new HashMap<>();
-    tokens.put("myTokenName", tokenValue);
+  @Test
+  public void versionPath() {
+    String result = underTest.versionPath(state);
 
-    return tokens;
+    assertThat(result, is(equalTo("azure/azcollection/1.2.0")));
   }
 }

--- a/nexus-repository-ansiblegalaxy/src/test/java/org/sonatype/nexus/plugins/ansiblegalaxy/internal/util/AnsibleGalaxyPathUtilsTest.java
+++ b/nexus-repository-ansiblegalaxy/src/test/java/org/sonatype/nexus/plugins/ansiblegalaxy/internal/util/AnsibleGalaxyPathUtilsTest.java
@@ -38,18 +38,32 @@ public class AnsibleGalaxyPathUtilsTest
   @Before
   public void setUp() {
     underTest = new AnsibleGalaxyPathUtils();
+    when(state.getTokens()).thenReturn(defaultTokens());
+  }
+
+  private Map<String, String> defaultTokens() {
     Map<String, String> tokens = new HashMap<>();
     tokens.put("author", "azure");
     tokens.put("module", "azcollection");
     tokens.put("version", "1.2.0");
-    when(state.getTokens()).thenReturn(tokens);
+    return tokens;
   }
 
   @Test
   public void versionListPath() {
     String result = underTest.versionListPath(state);
 
-    assertThat(result, is(equalTo("azure/azcollection/versions")));
+    assertThat(result, is(equalTo("azure/azcollection/versions1")));
+  }
+
+  @Test
+  public void versionListPathPaged() {
+    Map<String, String> tokens = defaultTokens();
+    tokens.put("pagenum", "3");
+    when(state.getTokens()).thenReturn(tokens);
+    String result = underTest.versionListPath(state);
+
+    assertThat(result, is(equalTo("azure/azcollection/versions3")));
   }
 
   @Test
@@ -65,4 +79,5 @@ public class AnsibleGalaxyPathUtilsTest
 
     assertThat(result, is(equalTo("azure/azcollection/1.2.0/artifact")));
   }
+
 }

--- a/nexus-repository-ansiblegalaxy/src/test/java/org/sonatype/nexus/plugins/ansiblegalaxy/internal/util/QueryTokenMatcherTest.java
+++ b/nexus-repository-ansiblegalaxy/src/test/java/org/sonatype/nexus/plugins/ansiblegalaxy/internal/util/QueryTokenMatcherTest.java
@@ -1,0 +1,127 @@
+/*
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2020-present Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+package org.sonatype.nexus.plugins.ansiblegalaxy.internal.util;
+
+import java.util.Map;
+
+import org.sonatype.goodies.testsupport.TestSupport;
+import org.sonatype.nexus.common.collect.AttributesMap;
+import org.sonatype.nexus.repository.view.Context;
+import org.sonatype.nexus.repository.view.Parameters;
+import org.sonatype.nexus.repository.view.Request;
+import org.sonatype.nexus.repository.view.matchers.token.TokenMatcher.State;
+
+import org.apache.commons.collections.MapUtils;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.when;
+
+public class QueryTokenMatcherTest
+    extends TestSupport
+{
+
+  private static final String PATH = "/api/v2/collections/azure/azcollection/versions/";
+
+  private QueryTokenMatcher underTest;
+
+  private Parameters parameters;
+
+  private AttributesMap attributes;
+
+  @Mock
+  Request request;
+
+  @Mock
+  Context context;
+
+  @Before
+  public void setUp() {
+    underTest = null;
+    parameters = new Parameters();
+    attributes = new AttributesMap();
+    when(request.getParameters()).thenReturn(parameters);
+    when(request.getPath()).thenReturn(PATH);
+    when(context.getRequest()).thenReturn(request);
+    when(context.getAttributes()).thenReturn(attributes);
+  }
+
+  @Test
+  public void testNonQueryUriWithoutQueryParams() {
+    underTest = new QueryTokenMatcher("/api/{apiversion}/collections/{author}/{module}/versions/");
+    boolean matches = underTest.matches(context);
+    assertTrue(matches);
+
+    State state = context.getAttributes().get(State.class);
+    assertThat(state, notNullValue());
+    Map<String, String> tokens = state.getTokens();
+    assertTrue(MapUtils.isNotEmpty(tokens));
+    assertThat(tokens.get("apiversion"), is(equalTo("v2")));
+    assertThat(tokens.get("author"), is(equalTo("azure")));
+    assertThat(tokens.get("module"), is(equalTo("azcollection")));
+    assertThat(tokens.get("pagenum"), nullValue());
+  }
+
+  @Test
+  public void testNonQueryUriWithQueryParam() {
+    underTest = new QueryTokenMatcher("/api/{apiversion}/collections/{author}/{module}/versions/");
+    parameters.set("test", "abc");
+    boolean matches = underTest.matches(context);
+    assertFalse(matches);
+
+    parameters.set("page", "1");
+    matches = underTest.matches(context);
+    assertFalse(matches);
+  }
+
+  @Test
+  public void testUrlWithoutQueryParam() {
+    underTest = new QueryTokenMatcher("/api/{apiversion}/collections/{author}/{module}/versions/?page={pagenum}");
+    boolean matches = underTest.matches(context);
+    assertFalse(matches);
+  }
+
+  @Test
+  public void testWithUnmatchinQueryParam() {
+    underTest = new QueryTokenMatcher("/api/{apiversion}/collections/{author}/{module}/versions/?page={pagenum}");
+    parameters.set("test", "abc");
+    boolean matches = underTest.matches(context);
+    assertFalse(matches);
+  }
+
+  @Test
+  public void testWithMatchingQueryParam() {
+    underTest = new QueryTokenMatcher("/api/{apiversion}/collections/{author}/{module}/versions/?page={pagenum}");
+    parameters.set("page", "5");
+    boolean matches = underTest.matches(context);
+    assertTrue(matches);
+
+    State state = context.getAttributes().get(State.class);
+    assertThat(state, notNullValue());
+    Map<String, String> tokens = state.getTokens();
+    assertTrue(MapUtils.isNotEmpty(tokens));
+    assertThat(tokens.get("apiversion"), is(equalTo("v2")));
+    assertThat(tokens.get("author"), is(equalTo("azure")));
+    assertThat(tokens.get("module"), is(equalTo("azcollection")));
+    assertThat(tokens.get("pagenum"), is(equalTo("5")));
+  }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
   </parent>
 
   <artifactId>nexus-repository-ansiblegalaxy-parent</artifactId>
-  <version>0.0.1-SNAPSHOT</version>
+  <version>0.1.0</version>
   <packaging>pom</packaging>
 
   <inceptionYear>2020</inceptionYear>


### PR DESCRIPTION
### Overview

This PR adds basic support for proxying Ansible Galaxy repositories through NXRM.

It has been tested with:
* Remote server URL https://galaxy.ansible.com/.
* `ansible-galaxy` client 2.10.3 with python version 3.9.1 on Mac OS.
* Installation of collections (untested with roles).

### Usage

1. Copy the plugin .kar to `{nexus_home}/deploy` directory.
1. Configure the proxy repository:
    <a target="_blank" href="https://user-images.githubusercontent.com/2243641/103445942-84d2f300-4c3f-11eb-8d95-a1bf9751e11e.png"><img src="https://user-images.githubusercontent.com/2243641/103445942-84d2f300-4c3f-11eb-8d95-a1bf9751e11e.png" alt="image" width="50%;"></a>
1. Provide the repository endpoint when using the `ansible-galaxy` client:
    ```bash
    ansible-galaxy collection install azure.azcollection -s http://localhost:8081/repository/ansible/
    ```

### Verification

After running the above collection install command:
* the repository browser will have the following components/assets:
    <a target="_blank" href="https://user-images.githubusercontent.com/2243641/103448511-266a3c80-4c60-11eb-8f46-e4b1c0af6742.png"><img src="https://user-images.githubusercontent.com/2243641/103448511-266a3c80-4c60-11eb-8f46-e4b1c0af6742.png" alt="image" width="25%;"></a>
* the NXRM HTTP request log will show the following requests were handled:
    ```
    172.17.0.1 - - [02/Jan/2021:00:49:47 +0000] "GET /repository/ansible/ HTTP/1.1" 404 - 1894 7 "ansible-galaxy/2.10.3 (Darwin; python:3.9.1)" [qtp292265577-50]
    172.17.0.1 - - [02/Jan/2021:00:49:47 +0000] "GET /repository/ansible/api HTTP/1.1" 200 - 253 580 "ansible-galaxy/2.10.3 (Darwin; python:3.9.1)" [qtp292265577-169]
    172.17.0.1 - - [02/Jan/2021:00:49:47 +0000] "GET /repository/ansible/api/v2/collections/azure/azcollection/versions/ HTTP/1.1" 200 - 1385 11 "ansible-galaxy/2.10.3 (Darwin; python:3.9.1)" [qtp292265577-181]
    172.17.0.1 - - [02/Jan/2021:00:49:47 +0000] "GET /repository/ansible/api/v2/collections/azure/azcollection/versions/?page=2 HTTP/1.1" 200 - 510 11 "ansible-galaxy/2.10.3 (Darwin; python:3.9.1)" [qtp292265577-50]
    172.17.0.1 - - [02/Jan/2021:00:49:47 +0000] "GET /repository/ansible/api/v2/collections/azure/azcollection/versions/1.3.1/ HTTP/1.1" 200 - 1088 7 "ansible-galaxy/2.10.3 (Darwin; python:3.9.1)" [qtp292265577-169]
    172.17.0.1 - - [02/Jan/2021:00:49:47 +0000] "GET /repository/ansible/download/azure-azcollection-1.3.1.tar.gz HTTP/1.1" 200 - 543481 26 "ansible-galaxy/2.10.3 (Darwin; python:3.9.1)" [qtp292265577-181]
    ```

### Limitations

This basic implementation is a starting point. The following is untested or unimplemented:
* Installing roles.
* Using a self-hosted Ansible Galaxy server/API.
* Browsing the repo in the UI is not implemented (errors are thrown when selecting assets).

cc @DarthHater @bhamail
