### PR TITLE
Fix for Nexus 3.31.0-01

### DIFF
--- a/nexus-repository-ansiblegalaxy/src/main/java/org/sonatype/nexus/plugins/ansiblegalaxy/internal/util/AnsibleGalaxyDataAccess.java
+++ b/nexus-repository-ansiblegalaxy/src/main/java/org/sonatype/nexus/plugins/ansiblegalaxy/internal/util/AnsibleGalaxyDataAccess.java
@@ -13,9 +13,7 @@
 package org.sonatype.nexus.plugins.ansiblegalaxy.internal.util;
 
 import java.io.IOException;
-import java.io.InputStream;
 import java.util.List;
-import java.util.function.Supplier;
 
 import javax.annotation.Nullable;
 import javax.inject.Named;
@@ -103,7 +101,7 @@ public class AnsibleGalaxyDataAccess
   public Content saveAsset(
       final StorageTx tx,
       final Asset asset,
-      final Supplier<InputStream> contentSupplier,
+      final TempBlob contentSupplier,
       final Payload payload) throws IOException
   {
     AttributesMap contentAttributes = null;
@@ -123,7 +121,7 @@ public class AnsibleGalaxyDataAccess
   public Content saveAsset(
       final StorageTx tx,
       final Asset asset,
-      final Supplier<InputStream> contentSupplier,
+      final TempBlob contentSupplier,
       final String contentType,
       @Nullable final AttributesMap contentAttributes) throws IOException
   {

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.sonatype.nexus.plugins</groupId>
     <artifactId>nexus-plugins</artifactId>
-    <version>3.29.1-01</version>
+    <version>3.31.0-01</version>
   </parent>
 
   <artifactId>nexus-repository-ansiblegalaxy-parent</artifactId>


### PR DESCRIPTION
Fixing DataAccess for `3.31.0-01` onwards.

This pull request makes the following changes:
* Update nexus-plugins parent to `3.31.0-01`
* Replace `Supplier<InputStream>` with `TempBlob`

It relates to the following issue #s:
* Fixes #6 

cc @DarthHater @bhamail @l3ender 
